### PR TITLE
fix: cookie domain normalization, redirect history, redirect cookie accumulation

### DIFF
--- a/src/http/cookies.ts
+++ b/src/http/cookies.ts
@@ -43,10 +43,12 @@ export class Cookies implements Iterable<Cookie> {
   }
 
   /**
-   * Generate a unique key for a cookie
+   * Generate a unique key for a cookie.
+   * Strips leading dot from domain per RFC 6265 §5.2.3.
    */
   private makeKey(name: string, domain?: string, path?: string): string {
-    return `${domain || ""}|${path || "/"}|${name}`;
+    const normalizedDomain = domain?.replace(/^\./, "") || "";
+    return `${normalizedDomain}|${path || "/"}|${name}`;
   }
 
   /**
@@ -56,7 +58,7 @@ export class Cookies implements Iterable<Cookie> {
     const cookie: Cookie = {
       name,
       value,
-      domain: options?.domain,
+      domain: options?.domain?.replace(/^\./, "") || undefined,
       path: options?.path || "/",
       expires: options?.expires,
       maxAge: options?.maxAge,
@@ -305,7 +307,7 @@ export class Cookies implements Iterable<Cookie> {
 
     for (const cookie of this.cookies.values()) {
       const domain = cookie.domain || "";
-      const includeSubdomains = domain.startsWith(".") ? "TRUE" : "FALSE";
+      const includeSubdomains = cookie.domain ? "TRUE" : "FALSE";
       const path = cookie.path || "/";
       const secure = cookie.secure ? "TRUE" : "FALSE";
       const expires = cookie.expires
@@ -339,7 +341,7 @@ export class Cookies implements Iterable<Cookie> {
 
       switch (lowerName) {
         case "domain":
-          cookie.domain = attrValue;
+          cookie.domain = attrValue?.replace(/^\./, "") || undefined;
           break;
         case "path":
           cookie.path = attrValue;

--- a/src/http/headers.ts
+++ b/src/http/headers.ts
@@ -8,6 +8,12 @@ export type HeadersInit =
   | Iterable<[string, string]>
   | Array<string | [string, string]>;
 
+export interface HeaderSegment {
+  statusCode: number;
+  statusText: string;
+  headers: Headers;
+}
+
 /**
  * Headers - Case-insensitive HTTP headers container
  *
@@ -199,29 +205,86 @@ export class Headers implements Iterable<[string, string]> {
   }
 
   /**
+   * Split raw headers buffer into per-response segments.
+   * When curl follows redirects, the header callback receives headers
+   * for every response in the chain. Each HTTP/ status line starts a new segment.
+   */
+  static splitRawByResponse(raw: string | Buffer): Array<HeaderSegment> {
+    const text = Buffer.isBuffer(raw) ? raw.toString("utf-8") : raw;
+    const lines = text.split(/\r?\n/);
+    const segments: HeaderSegment[] = [];
+
+    let currentStatusCode = 0;
+    let currentStatusText = "";
+    let currentHeaderLines: string[] = [];
+
+    for (const line of lines) {
+      const statusMatch = line.match(/^HTTP\/[\d.]+\s+(\d{3})\s*(.*)/);
+      if (statusMatch) {
+        // Push previous segment if we have one
+        if (currentStatusCode > 0) {
+          segments.push({
+            statusCode: currentStatusCode,
+            statusText: currentStatusText,
+            headers: Headers.fromHeaderLines(currentHeaderLines),
+          });
+        }
+
+        currentStatusCode = parseInt(statusMatch[1], 10);
+        currentStatusText = statusMatch[2]?.trim() || "";
+        currentHeaderLines = [];
+
+        continue;
+      }
+
+      if (!line.trim()) continue;
+
+      // Handle continuation lines (starting with space/tab)
+      if ((line.startsWith(" ") || line.startsWith("\t")) && currentHeaderLines.length > 0) {
+        currentHeaderLines[currentHeaderLines.length - 1] += line;
+      } else {
+        currentHeaderLines.push(line);
+      }
+    }
+
+    // Push the last segment
+    if (currentStatusCode > 0) {
+      segments.push({
+        statusCode: currentStatusCode,
+        statusText: currentStatusText,
+        headers: Headers.fromHeaderLines(currentHeaderLines),
+      });
+    }
+
+    return segments;
+  }
+
+  /**
+   * Create Headers from an array of "Name: Value" lines
+   */
+  private static fromHeaderLines(lines: string[]): Headers {
+    const headers = new Headers();
+
+    for (const line of lines) {
+      const colonIdx = line.indexOf(":");
+      if (colonIdx <= 0) continue;
+
+      const name = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim();
+      headers.append(name, value);
+    }
+
+    return headers;
+  }
+
+  /**
    * Create Headers from curl response headers
    * Parses raw header lines (including status line)
    */
   static fromRaw(raw: string | Buffer): Headers {
-    const headers = new Headers();
     const text = Buffer.isBuffer(raw) ? raw.toString("utf-8") : raw;
-    const lines = text.split(/\r?\n/);
-
-    for (const line of lines) {
-      // Skip empty lines and status line
-      if (!line || line.startsWith("HTTP/")) {
-        continue;
-      }
-
-      const colonIdx = line.indexOf(":");
-      if (colonIdx > 0) {
-        const name = line.slice(0, colonIdx).trim();
-        const value = line.slice(colonIdx + 1).trim();
-        headers.append(name, value);
-      }
-    }
-
-    return headers;
+    const lines = text.split(/\r?\n/).filter((line) => line && !line.startsWith("HTTP/"));
+    return Headers.fromHeaderLines(lines);
   }
 
   /**

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -11,10 +11,14 @@ import { HTTPError } from "../utils/errors.js";
 export interface ResponseInit {
   content?: Buffer;
   rawHeaders?: Buffer | string;
+  headers?: Headers;
   curl?: Curl;
   requestUrl?: string;
   elapsed?: number;
   history?: Response[];
+  statusCode?: number;
+  statusText?: string;
+  url?: string;
 }
 
 /**
@@ -35,6 +39,12 @@ export class Response {
   readonly localIp: string | null;
   readonly localPort: number;
   readonly redirectCount: number;
+  /**
+   * URL of the next redirect that was NOT followed, or null if all redirects
+   * were followed. When allowRedirects is true (default), this will be null
+   * after a successful redirect chain. Use `response.url` for the final URL,
+   * or `response.history` for intermediate Response objects at each redirect step.
+   */
   readonly redirectUrl: string | null;
   readonly httpVersion: number;
   readonly contentType: string | null;
@@ -46,6 +56,7 @@ export class Response {
   private _content: Buffer | null = null;
   private _stream: AsyncIterable<Buffer> | null = null;
   private _encoding: BufferEncoding = "utf-8";
+  private readonly _statusText: string | null = null;
 
   constructor(init: ResponseInit) {
     this.requestUrl = init.requestUrl || "";
@@ -57,31 +68,18 @@ export class Response {
       this._content = init.content;
     }
 
-    // Parse headers if provided
-    if (init.rawHeaders) {
+    // Use pre-parsed headers if provided, otherwise parse from raw
+    if (init.headers) {
+      this.headers = init.headers;
+    } else if (init.rawHeaders) {
       this.headers = Headers.fromRaw(init.rawHeaders);
     } else {
       this.headers = new Headers();
     }
 
-    // Extract cookies from headers
-    this.cookies = new Cookies();
-    const setCookies = this.headers.getAll("set-cookie");
-    for (const setCookie of setCookies) {
-      try {
-        const cookie = Cookies.parseSetCookie(
-          setCookie,
-          this.requestUrl ? new URL(this.requestUrl) : undefined
-        );
-        this.cookies.set(cookie.name, cookie.value, cookie);
-      } catch {
-        // Ignore invalid cookies
-      }
-    }
-
     // Get metadata from curl handle
     if (init.curl) {
-      this.url = init.curl.getEffectiveUrl() || this.requestUrl;
+      this.url = init.url || init.curl.getEffectiveUrl() || this.requestUrl;
       this.statusCode = init.curl.getResponseCode();
       this.primaryIp = init.curl.getPrimaryIp();
       this.primaryPort = init.curl.getPrimaryPort();
@@ -90,13 +88,10 @@ export class Response {
       this.redirectCount = init.curl.getRedirectCount();
       this.redirectUrl = init.curl.getRedirectUrl();
       this.httpVersion = init.curl.getHttpVersion();
-      this.contentType = init.curl.getContentType();
-
-      // Detect encoding from content-type
-      this._encoding = this.detectEncoding();
+      this.contentType = init.curl.getContentType() || this.headers.get("content-type");
     } else {
-      this.url = this.requestUrl;
-      this.statusCode = 0;
+      this.url = init.url || this.requestUrl;
+      this.statusCode = init.statusCode || 0;
       this.primaryIp = null;
       this.primaryPort = 0;
       this.localIp = null;
@@ -105,7 +100,31 @@ export class Response {
       this.redirectUrl = null;
       this.httpVersion = CurlHttpVersion.CURL_HTTP_VERSION_1_1;
       this.contentType = this.headers.get("content-type");
-      this._encoding = this.detectEncoding();
+    }
+
+    // Store wire status text (falls back to lookup table in getter)
+    this._statusText = init.statusText || null;
+
+    // Detect encoding from content-type
+    this._encoding = this.detectEncoding();
+
+    // Extract cookies from headers using effective URL (after redirects)
+    this.cookies = new Cookies();
+
+    const cookieUrl = this.url;
+    const setCookies = this.headers.getAll("set-cookie");
+
+    for (const setCookie of setCookies) {
+      try {
+        const cookie = Cookies.parseSetCookie(
+          setCookie,
+          cookieUrl ? new URL(cookieUrl) : undefined,
+        );
+
+        this.cookies.set(cookie.name, cookie.value, cookie);
+      } catch {
+        // Ignore invalid cookies
+      }
     }
   }
 
@@ -136,6 +155,20 @@ export class Response {
   }
 
   /**
+   * HTTP status code (alias for statusCode)
+   */
+  get status(): number {
+    return this.statusCode;
+  }
+
+  /**
+   * HTTP status reason phrase (alias for reason)
+   */
+  get statusText(): string {
+    return this.reason;
+  }
+
+  /**
    * Check if response was successful (2xx status)
    */
   get ok(): boolean {
@@ -146,7 +179,7 @@ export class Response {
    * Get status reason phrase
    */
   get reason(): string {
-    return HTTP_STATUS_CODES[this.statusCode] || "Unknown";
+    return this._statusText || HTTP_STATUS_CODES[this.statusCode] || "Unknown";
   }
 
   /**

--- a/src/http/session.ts
+++ b/src/http/session.ts
@@ -193,23 +193,71 @@ export class Session {
 
       const rawHeaders: Buffer = Buffer.concat(headerChunks);
       let content: Buffer = Buffer.concat(bodyChunks);
+
+      // Split raw headers into per-response segments for redirect history
+      const segments = Headers.splitRawByResponse(rawHeaders);
+
+      // Build redirect history from intermediate responses (all except last)
+      const history: Response[] = [];
+      let currentUrl = resolvedUrl;
+
+      if (segments.length > 1) {
+        for (let i = 0; i < segments.length - 1; i++) {
+          const seg = segments[i];
+
+          const intermediateResponse = new Response({
+            headers: seg.headers,
+            requestUrl: currentUrl,
+            statusCode: seg.statusCode,
+            statusText: seg.statusText,
+            url: currentUrl,
+          });
+
+          // Update session cookies from intermediate response
+          for (const cookie of intermediateResponse.cookies) {
+            this._cookies.set(cookie.name, cookie.value, cookie);
+          }
+
+          history.push(intermediateResponse);
+
+          // Resolve next URL from Location header
+          const location = seg.headers.get("location");
+          if (location) {
+            try {
+              currentUrl = new URL(location, currentUrl).href;
+            } catch {
+              currentUrl = location;
+            }
+          }
+        }
+      }
+
+      // Use only the last segment's headers for content decoding
+      const lastSegment = segments.length > 0 ? segments[segments.length - 1] : null;
+
       if (!mergedOptions.stream && mergedOptions.decodeContent !== false) {
-        const decoded = this.decodeContent(content, Headers.fromRaw(rawHeaders).get("content-encoding"));
+        const encoding = lastSegment
+          ? lastSegment.headers.get("content-encoding")
+          : Headers.fromRaw(rawHeaders).get("content-encoding");
+        const decoded = this.decodeContent(content, encoding);
         if (decoded) {
           content = decoded;
         }
       }
 
-      // Build response
       const response = new Response({
         content,
-        rawHeaders,
+        headers: lastSegment?.headers,
         curl,
         requestUrl: resolvedUrl,
         elapsed,
+        history,
+        // Pass the resolved final URL from redirect chain, in case
+        // CURLINFO_EFFECTIVE_URL doesn't reflect the redirect target
+        url: history.length > 0 ? currentUrl : undefined,
       });
 
-      // Update session cookies from response
+      // Update session cookies from final response
       for (const cookie of response.cookies) {
         this._cookies.set(cookie.name, cookie.value, cookie);
       }

--- a/tests/cookies.test.ts
+++ b/tests/cookies.test.ts
@@ -155,4 +155,88 @@ describe("Cookies", () => {
       expect(cookie.secure).toBe(true);
     });
   });
+
+  describe("RFC 6265 domain dot handling", () => {
+    it("should strip leading dot from domain on set()", () => {
+      const cookies = new Cookies();
+      cookies.set("session", "abc", { domain: ".example.com" });
+      const cookie = cookies.getCookie("session");
+      expect(cookie?.domain).toBe("example.com");
+    });
+
+    it("should deduplicate dotted and dotless domains", () => {
+      const cookies = new Cookies();
+      cookies.set("session", "first", { domain: ".example.com" });
+      cookies.set("session", "second", { domain: "example.com" });
+      expect(cookies.size).toBe(1);
+      expect(cookies.get("session")).toBe("second");
+    });
+
+    it("should find cookie regardless of dot prefix in get()", () => {
+      const cookies = new Cookies();
+      cookies.set("session", "abc", { domain: "example.com" });
+      expect(cookies.get("session", ".example.com")).toBe("abc");
+
+      const cookies2 = new Cookies();
+      cookies2.set("session", "abc", { domain: ".example.com" });
+      expect(cookies2.get("session", "example.com")).toBe("abc");
+    });
+
+    it("should normalize domain in getCookie() lookup", () => {
+      const cookies = new Cookies();
+      cookies.set("session", "abc", { domain: ".example.com" });
+      const cookie = cookies.getCookie("session", ".example.com", "/");
+      expect(cookie).not.toBeNull();
+      expect(cookie?.domain).toBe("example.com");
+    });
+
+    it("should delete cookie using dotted domain", () => {
+      const cookies = new Cookies();
+      cookies.set("session", "abc", { domain: ".example.com" });
+      cookies.delete("session", ".example.com");
+      expect(cookies.has("session")).toBe(false);
+    });
+
+    it("should strip leading dot in parseSetCookie()", () => {
+      const cookie = Cookies.parseSetCookie("session=abc; Domain=.example.com");
+      expect(cookie.domain).toBe("example.com");
+    });
+
+    it("should match subdomains via getForUrl()", () => {
+      const cookies = new Cookies();
+      cookies.set("token", "xyz", { domain: ".sub.example.com" });
+
+      const exact = cookies.getForUrl("https://sub.example.com/");
+      expect(exact.map((c) => c.name)).toContain("token");
+
+      const deep = cookies.getForUrl("https://deep.sub.example.com/");
+      expect(deep.map((c) => c.name)).toContain("token");
+
+      const parent = cookies.getForUrl("https://example.com/");
+      expect(parent.map((c) => c.name)).not.toContain("token");
+    });
+
+    it("should match domains case-insensitively", () => {
+      const cookies = new Cookies();
+      cookies.set("token", "xyz", { domain: ".Example.COM" });
+
+      const matched = cookies.getForUrl("https://example.com/");
+      expect(matched.map((c) => c.name)).toContain("token");
+    });
+
+    it("should normalize dotted domains from Netscape format", () => {
+      const text = ".example.com\tTRUE\t/\tFALSE\t0\tsession\tabc";
+      const cookies = Cookies.fromNetscapeFormat(text);
+      const cookie = cookies.getCookie("session");
+      expect(cookie?.domain).toBe("example.com");
+    });
+
+    it("should export normalized domain in Netscape format", () => {
+      const cookies = new Cookies();
+      cookies.set("session", "abc", { domain: ".example.com" });
+      const output = cookies.toNetscapeFormat();
+      expect(output).toContain("example.com");
+      expect(output).not.toMatch(/\t\.example\.com\t/);
+    });
+  });
 });

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -2,6 +2,7 @@
  * Tests for HTTP requests using Session class
  */
 import { Session } from "../src/http/session.js";
+import { Headers } from "../src/http/headers.js";
 import { get, post, put, del, patch } from "../src/public.js";
 
 describe("Session", () => {
@@ -154,6 +155,53 @@ describe("Session", () => {
         })
       ).rejects.toThrow();
     });
+
+    it("should populate response.history for redirect chain", async () => {
+      const resp = await session.get(`${globalThis.TEST_SERVER_URL}/redirect/3`);
+      expect(resp.statusCode).toBe(200);
+      expect(resp.history.length).toBe(3);
+      for (const hop of resp.history) {
+        expect(hop.statusCode).toBe(302);
+      }
+    });
+
+    it("should track URLs through the redirect chain", async () => {
+      const resp = await session.get(`${globalThis.TEST_SERVER_URL}/redirect/2`);
+      expect(resp.history.length).toBe(2);
+      expect(resp.history[0].requestUrl).toContain("/redirect/2");
+      expect(resp.history[1].requestUrl).toContain("/redirect/1");
+    });
+
+    it("should have empty history when no redirects occur", async () => {
+      const resp = await session.get(`${globalThis.TEST_SERVER_URL}/get`);
+      expect(resp.history).toEqual([]);
+    });
+
+    it("should have empty history when redirects are disabled", async () => {
+      const resp = await session.get(`${globalThis.TEST_SERVER_URL}/redirect/2`, {
+        allowRedirects: false,
+      });
+      expect(resp.history).toEqual([]);
+    });
+
+    it("should extract cookies from intermediate redirect hops", async () => {
+      const resp = await session.get(`${globalThis.TEST_SERVER_URL}/redirect-with-cookie/2`);
+      expect(resp.statusCode).toBe(200);
+      // Cookies set at hop 2, hop 1, and hop 0 should all be in the session
+      expect(session.cookies.get("hop_2")).toBe("value_2");
+      expect(session.cookies.get("hop_1")).toBe("value_1");
+      expect(session.cookies.get("hop_0")).toBe("value_0");
+    });
+
+    it("should make accumulated redirect cookies available on subsequent requests", async () => {
+      await session.get(`${globalThis.TEST_SERVER_URL}/redirect-with-cookie/2`);
+      // Session now has cookies from all hops; a follow-up request should send them
+      const resp = await session.get(`${globalThis.TEST_SERVER_URL}/cookies`);
+      const json = resp.json() as { cookies: Record<string, string> };
+      expect(json.cookies["hop_2"]).toBe("value_2");
+      expect(json.cookies["hop_1"]).toBe("value_1");
+      expect(json.cookies["hop_0"]).toBe("value_0");
+    });
   });
 
   describe("Delays", () => {
@@ -164,6 +212,33 @@ describe("Session", () => {
       expect(resp.statusCode).toBe(200);
       expect(elapsed).toBeGreaterThanOrEqual(900); // Allow some tolerance
     });
+  });
+});
+
+describe("Headers.splitRawByResponse", () => {
+  it("should split multi-response raw headers into segments", () => {
+    const raw =
+      "HTTP/1.1 302 Found\r\nLocation: /get\r\nSet-Cookie: a=1\r\n\r\n" +
+      "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n";
+
+    const segments = Headers.splitRawByResponse(raw);
+    expect(segments.length).toBe(2);
+
+    expect(segments[0].statusCode).toBe(302);
+    expect(segments[0].statusText).toBe("Found");
+    expect(segments[0].headers.get("location")).toBe("/get");
+    expect(segments[0].headers.get("set-cookie")).toBe("a=1");
+
+    expect(segments[1].statusCode).toBe(200);
+    expect(segments[1].statusText).toBe("OK");
+    expect(segments[1].headers.get("content-type")).toBe("application/json");
+  });
+
+  it("should return a single segment for non-redirect responses", () => {
+    const raw = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n";
+    const segments = Headers.splitRawByResponse(raw);
+    expect(segments.length).toBe(1);
+    expect(segments[0].statusCode).toBe(200);
   });
 });
 

--- a/tests/mock-server.ts
+++ b/tests/mock-server.ts
@@ -119,6 +119,17 @@ export async function startMockServer(port = 0): Promise<number> {
     }
   });
 
+  // Redirect endpoint that sets a cookie at each hop
+  server.get<{ Params: { n: string } }>("/redirect-with-cookie/:n", async (request, reply) => {
+    const n = parseInt(request.params.n, 10);
+    reply.setCookie(`hop_${n}`, `value_${n}`, { path: "/" });
+    if (n > 0) {
+      reply.redirect(`/redirect-with-cookie/${n - 1}`);
+    } else {
+      reply.redirect("/cookies");
+    }
+  });
+
   // Absolute redirect endpoint
   server.get<{ Params: { n: string } }>("/absolute-redirect/:n", async (request, reply) => {
     const n = parseInt(request.params.n, 10);


### PR DESCRIPTION
- Parse curl redirect chains into per-response header segments, building response.history with intermediate Response objects
- Extract cookies from each redirect hop, not just the final response
- Add status/statusText aliases and preserve wire reason phrases on Response
- Fix RFC 6265 §5.2.3 cookie domain dot normalization (strip leading . on set, parse, match, and Netscape format)
- Add appropriate tests for all changes

Closes #1 