### PR TITLE
fix: distinguish host-only and Domain-attribute cookies of the same name/path/domain

### DIFF
--- a/src/http/cookies.ts
+++ b/src/http/cookies.ts
@@ -6,6 +6,7 @@ export interface Cookie {
   name: string;
   value: string;
   domain?: string;
+  domainSpecified?: boolean; // true: Domain attribute was explicit; false/absent: host-only
   path?: string;
   expires?: Date;
   maxAge?: number;
@@ -16,6 +17,7 @@ export interface Cookie {
 
 export interface CookieOptions {
   domain?: string;
+  domainSpecified?: boolean;
   path?: string;
   expires?: Date;
   maxAge?: number;
@@ -46,19 +48,22 @@ export class Cookies implements Iterable<Cookie> {
    * Generate a unique key for a cookie.
    * Strips leading dot from domain per RFC 6265 §5.2.3.
    */
-  private makeKey(name: string, domain?: string, path?: string): string {
+  private makeKey(name: string, domain?: string, path?: string, domainSpecified?: boolean): string {
     const normalizedDomain = domain?.replace(/^\./, "") || "";
-    return `${normalizedDomain}|${path || "/"}|${name}`;
+    return `${normalizedDomain}|${path || "/"}|${name}|${domainSpecified ? "1" : "0"}`;
   }
 
   /**
    * Set a cookie
    */
   set(name: string, value: string, options?: CookieOptions): void {
+    const domain = options?.domain?.replace(/^\./, "") || undefined;
+    const domainSpecified = options?.domainSpecified ?? Boolean(domain);
     const cookie: Cookie = {
       name,
       value,
-      domain: options?.domain?.replace(/^\./, "") || undefined,
+      domain,
+      domainSpecified,
       path: options?.path || "/",
       expires: options?.expires,
       maxAge: options?.maxAge,
@@ -67,7 +72,7 @@ export class Cookies implements Iterable<Cookie> {
       sameSite: options?.sameSite,
     };
 
-    const key = this.makeKey(name, cookie.domain, cookie.path);
+    const key = this.makeKey(name, cookie.domain, cookie.path, cookie.domainSpecified);
     this.cookies.set(key, cookie);
   }
 
@@ -75,14 +80,17 @@ export class Cookies implements Iterable<Cookie> {
    * Get a cookie value
    */
   get(name: string, domain?: string, path?: string): string | null {
-    // Try exact match first
-    const key = this.makeKey(name, domain, path);
-    const exact = this.cookies.get(key);
-    if (exact) {
-      return exact.value;
+    // Pass 1: exact scope match, no subdomain/path-prefix fuzz. Resolves a
+    // host-only vs. Domain-attribute collision deterministically by
+    // insertion order, and keeps a more specific cookie from being shadowed
+    // by a broader one that happened to be inserted first.
+    for (const cookie of this.cookies.values()) {
+      if (cookie.name !== name) continue;
+      if (!this.matchesExactScope(cookie, domain, path)) continue;
+      return cookie.value;
     }
 
-    // Search for matching cookie
+    // Pass 2: fuzzy fallback (subdomain/path-prefix matching)
     for (const cookie of this.cookies.values()) {
       if (cookie.name !== name) continue;
 
@@ -104,10 +112,11 @@ export class Cookies implements Iterable<Cookie> {
    * Get a cookie object
    */
   getCookie(name: string, domain?: string, path?: string): Cookie | null {
-    const key = this.makeKey(name, domain, path);
-    const exact = this.cookies.get(key);
-    if (exact) {
-      return exact;
+    // See get() above for the two-pass rationale.
+    for (const cookie of this.cookies.values()) {
+      if (cookie.name !== name) continue;
+      if (!this.matchesExactScope(cookie, domain, path)) continue;
+      return cookie;
     }
 
     for (const cookie of this.cookies.values()) {
@@ -131,12 +140,37 @@ export class Cookies implements Iterable<Cookie> {
    * Delete a cookie
    */
   delete(name: string, domain?: string, path?: string): boolean {
-    const key = this.makeKey(name, domain, path);
-    if (this.cookies.has(key)) {
-      return this.cookies.delete(key);
+    // Pass 1: delete an exact-key collision pair (a host-only and a
+    // Domain-attribute cookie sharing the same exact domain/path) without
+    // cascading into broader fuzzy matches. Deliberately mirrors the old
+    // single-key exact lookup's own defaulting (path defaults to "/", a
+    // missing domain normalizes to "") rather than using matchesExactScope()
+    // directly: that helper treats an omitted argument as "unconstrained on
+    // that axis", which is fine for get()/getCookie() (they return at most
+    // one value either way) but would be destructive here -- it would make
+    // "exact" match every cookie along the omitted axis, silently deleting
+    // far more than the one (or colliding pair of) cookie(s) a caller who
+    // omitted path actually meant. Checking both possible domainSpecified
+    // values at the same literal key is what makes this still delete both
+    // halves of a genuine collision, which the old single 3-part key could
+    // never represent.
+    const exactPath = path || "/";
+    const keyHostOnly = this.makeKey(name, domain, exactPath, false);
+    const keyDomainSpecified = this.makeKey(name, domain, exactPath, true);
+    let exactDeleted = false;
+    if (this.cookies.has(keyHostOnly)) {
+      this.cookies.delete(keyHostOnly);
+      exactDeleted = true;
+    }
+    if (this.cookies.has(keyDomainSpecified)) {
+      this.cookies.delete(keyDomainSpecified);
+      exactDeleted = true;
+    }
+    if (exactDeleted) {
+      return true;
     }
 
-    // Delete all matching cookies
+    // Pass 2: fuzzy fallback — delete every fuzzy match.
     let deleted = false;
     for (const [key, cookie] of this.cookies) {
       if (cookie.name !== name) continue;
@@ -248,6 +282,31 @@ export class Cookies implements Iterable<Cookie> {
   }
 
   /**
+   * Check whether a cookie's stored domain/path are an exact match for a
+   * query's domain/path (no subdomain or path-prefix fuzz). A domain or
+   * path argument that isn't provided imposes no constraint, matching the
+   * fuzzy scan's own "unconstrained means match anything" convention. A
+   * cookie missing the corresponding field is never an exact match for a
+   * provided argument -- it's left for the fuzzy fallback, which already
+   * treats a missing field as an unconditional pass-through.
+   */
+  private matchesExactScope(cookie: Cookie, domain?: string, path?: string): boolean {
+    if (domain) {
+      if (!cookie.domain) return false;
+      const normalizedQuery = domain.toLowerCase().replace(/^\./, "");
+      const normalizedCookie = cookie.domain.toLowerCase().replace(/^\./, "");
+      if (normalizedCookie !== normalizedQuery) return false;
+    }
+
+    if (path) {
+      if (!cookie.path) return false;
+      if (cookie.path !== path) return false;
+    }
+
+    return true;
+  }
+
+  /**
    * Check if cookie domain matches request domain
    */
   private matchesDomain(cookieDomain: string, requestDomain: string): boolean {
@@ -307,7 +366,7 @@ export class Cookies implements Iterable<Cookie> {
 
     for (const cookie of this.cookies.values()) {
       const domain = cookie.domain || "";
-      const includeSubdomains = cookie.domain ? "TRUE" : "FALSE";
+      const includeSubdomains = cookie.domainSpecified ? "TRUE" : "FALSE";
       const path = cookie.path || "/";
       const secure = cookie.secure ? "TRUE" : "FALSE";
       const expires = cookie.expires
@@ -342,6 +401,7 @@ export class Cookies implements Iterable<Cookie> {
       switch (lowerName) {
         case "domain":
           cookie.domain = attrValue?.replace(/^\./, "") || undefined;
+          cookie.domainSpecified = true;
           break;
         case "path":
           cookie.path = attrValue;
@@ -373,6 +433,7 @@ export class Cookies implements Iterable<Cookie> {
     if (requestUrl) {
       if (!cookie.domain) {
         cookie.domain = requestUrl.hostname;
+        cookie.domainSpecified = false;
       }
       if (!cookie.path) {
         cookie.path = requestUrl.pathname.replace(/\/[^/]*$/, "") || "/";
@@ -397,10 +458,11 @@ export class Cookies implements Iterable<Cookie> {
 
       const parts = line.split("\t");
       if (parts.length >= 7) {
-        const [domain, , path, secure, expires, name, value] = parts;
+        const [domain, includeSubdomains, path, secure, expires, name, value] = parts;
 
         cookies.set(name, value, {
           domain,
+          domainSpecified: includeSubdomains === "TRUE",
           path,
           secure: secure === "TRUE",
           expires: expires !== "0" ? new Date(parseInt(expires, 10) * 1000) : undefined,

--- a/tests/cookies.test.ts
+++ b/tests/cookies.test.ts
@@ -239,4 +239,176 @@ describe("Cookies", () => {
       expect(output).not.toMatch(/\t\.example\.com\t/);
     });
   });
+
+  describe("host-only vs. Domain-attribute cookie coexistence", () => {
+    it("keeps a host-only and a Domain-attribute cookie of the same name/path/domain as two records", () => {
+      // NOTE: both cookies here are explicitly given the SAME domain value
+      // ("example.com") so this genuinely exercises the collision makeKey()
+      // is supposed to resolve. An earlier version of this test omitted
+      // `domain` on the host-only cookie, which passes trivially even
+      // without this patch (the two calls end up with different domain
+      // values -- "" vs "example.com" -- so makeKey() would separate them
+      // either way, regardless of whether domainSpecified exists). See the
+      // spec's "Concrete repro" note about this exact pitfall.
+      const cookies = new Cookies();
+      cookies.set("sess", "host-only-value", { path: "/", domain: "example.com", domainSpecified: false });
+      cookies.set("sess", "domain-value", { path: "/", domain: "example.com", domainSpecified: true });
+      expect(cookies.size).toBe(2);
+    });
+
+    it("marks a cookie from parseSetCookie without a Domain attribute as domainSpecified: false", () => {
+      const cookie = Cookies.parseSetCookie(
+        "sess=abc",
+        new URL("https://api.example.com/")
+      );
+      expect(cookie.domain).toBe("api.example.com");
+      expect(cookie.domainSpecified).toBe(false);
+    });
+
+    it("marks a cookie from parseSetCookie with an explicit Domain attribute as domainSpecified: true", () => {
+      const cookie = Cookies.parseSetCookie(
+        "sess=abc; Domain=example.com",
+        new URL("https://api.example.com/")
+      );
+      expect(cookie.domain).toBe("example.com");
+      expect(cookie.domainSpecified).toBe(true);
+    });
+
+    it("preserves domainSpecified through the Netscape format round-trip for both cookie kinds", () => {
+      // Both cookies are given the SAME domain value here, deliberately —
+      // this is the real shape parseSetCookie()'s request-hostname fallback
+      // produces for a host-only cookie (domain backfilled from the URL,
+      // domainSpecified explicitly false). A host-only cookie with no domain
+      // at all doesn't discriminate old (`cookie.domain ? "TRUE" : "FALSE"`)
+      // from new (`cookie.domainSpecified ? ...`) toNetscapeFormat() logic,
+      // since `cookie.domain` and `cookie.domainSpecified` agree by
+      // construction in that case.
+      const original = new Cookies();
+      original.set("host_only", "a", { path: "/", domain: "example.com", domainSpecified: false });
+      original.set("domain_scoped", "b", { path: "/", domain: "example.com" });
+
+      const restored = Cookies.fromNetscapeFormat(original.toNetscapeFormat());
+
+      expect(restored.getCookie("host_only")?.domainSpecified).toBeFalsy();
+      expect(restored.getCookie("domain_scoped")?.domainSpecified).toBe(true);
+    });
+
+    it("reproduces the bug via the actual parseSetCookie() -> set() production path (response.ts:119-124)", () => {
+      // This is the realistic trigger path — see the spec's "Concrete repro"
+      // and "Correction" notes. A repro built from direct set() calls with
+      // hand-built options does NOT exercise this and will pass even when
+      // the underlying bug (missing `domainSpecified = false` in the
+      // request-hostname fallback) is present.
+      const url = new URL("https://example.com/");
+      const hostOnly = Cookies.parseSetCookie("sess=host-only-value", url);
+      const domainScoped = Cookies.parseSetCookie(
+        "sess=domain-value; Domain=example.com",
+        url
+      );
+
+      const jar = new Cookies();
+      jar.set(hostOnly.name, hostOnly.value, hostOnly);
+      jar.set(domainScoped.name, domainScoped.value, domainScoped);
+
+      expect(jar.size).toBe(2);
+    });
+
+    it("resolves get()/getCookie() for a colliding pair by insertion order, regardless of which one is host-only", () => {
+      // Regression guard: an earlier draft of this fix left get()/getCookie()
+      // an "exact key" fast path that queries with the caller's literal
+      // domain argument. Since that path computed its lookup key with
+      // domainSpecified defaulting to false, it would return whichever
+      // record happened to be host-only, independent of insertion order --
+      // contradicting the linear-scan fallback's own first-match semantics
+      // for every other case. Both orderings must agree with "first
+      // inserted wins".
+      const domainFirst = new Cookies();
+      domainFirst.set("sess", "domain-value", { path: "/", domain: "example.com" });
+      domainFirst.set("sess", "host-only-value", { path: "/" });
+      expect(domainFirst.get("sess")).toBe("domain-value");
+      expect(domainFirst.getCookie("sess")?.value).toBe("domain-value");
+
+      const hostOnlyFirst = new Cookies();
+      hostOnlyFirst.set("sess", "host-only-value", { path: "/" });
+      hostOnlyFirst.set("sess", "domain-value", { path: "/", domain: "example.com" });
+      expect(hostOnlyFirst.get("sess")).toBe("host-only-value");
+      expect(hostOnlyFirst.getCookie("sess")?.value).toBe("host-only-value");
+    });
+
+    it("still deduplicates two Domain-attribute cookies that differ only by leading dot", () => {
+      // Regression guard: this existing behavior (see the "RFC 6265 domain dot
+      // handling" describe block, "should deduplicate dotted and dotless
+      // domains") must not change — both cookies here are domain-specified,
+      // so they still collide on the same key as before this patch.
+      const cookies = new Cookies();
+      cookies.set("session", "first", { domain: ".example.com" });
+      cookies.set("session", "second", { domain: "example.com" });
+      expect(cookies.size).toBe(1);
+      expect(cookies.get("session")).toBe("second");
+    });
+
+    it("still prefers an exact domain/path match over a broader fuzzy match, independent of insertion order (regression guard, Revision note 2)", () => {
+      // Regression guard for the exact-key fast-path removal above (see
+      // "get()/getCookie()/delete() disambiguation"): this must keep working
+      // for ORDINARY callers, unrelated to host-only cookies or this patch's
+      // own collision case. Requires the two-pass exact-then-fuzzy fix.
+      const broadFirst = new Cookies();
+      broadFirst.set("sess", "broad", { domain: "example.com" });
+      broadFirst.set("sess", "specific", { domain: "app.example.com" });
+      expect(broadFirst.get("sess", "app.example.com")).toBe("specific");
+
+      const specificFirst = new Cookies();
+      specificFirst.set("sess", "specific", { domain: "app.example.com" });
+      specificFirst.set("sess", "broad", { domain: "example.com" });
+      expect(specificFirst.get("sess", "app.example.com")).toBe("specific");
+    });
+
+    it("documents a known, currently out-of-scope gap: getForUrl() still sends a host-only cookie to a subdomain (Revision note 2)", () => {
+      // KNOWN GAP, not fixed by this patch — tracked separately under
+      // "Explicitly out of scope" in this spec. This test documents CURRENT
+      // behavior, not desired behavior: it will need to flip to `.toBe(false)`
+      // once matchesDomain()/getForUrl() are taught to consult
+      // domainSpecified in that separate follow-up. Do not "fix" this by
+      // changing matchesDomain() as part of this PR.
+      const cookies = new Cookies();
+      cookies.set("sess", "host-only-value", { domain: "example.com", domainSpecified: false });
+      const matches = cookies.getForUrl("https://sub.example.com/");
+      expect(matches.some((c) => c.value === "host-only-value")).toBe(true);
+    });
+
+    it("delete() does not cascade across an omitted path when scoping by domain, and still deletes both records of an exact collision", () => {
+      // Regression guard: matchesExactScope() treats an omitted domain/path
+      // argument as "unconstrained on that axis" -- fine for get()/getCookie()
+      // (they return at most one value either way) but destructive for
+      // delete() if pass 1 scanned with it, since it would delete every
+      // cookie fuzzy-matching the omitted axis instead of only the exact
+      // match. delete()'s pass 1 avoids this by NOT scanning at all: it
+      // builds the exact Map key(s) set() would have used (domain as given,
+      // path defaulting to "/" the same way the old pre-patch fast path did)
+      // and looks each one up directly, trying both domainSpecified values
+      // to catch a genuine collision. A direct key lookup can't cascade
+      // regardless of which arguments are supplied -- it either hits the
+      // literal key(s) or it doesn't -- which is what keeps the omitted-path
+      // case below scoped to a single cookie, matching pre-patch behavior
+      // exactly.
+      const byPath = new Cookies();
+      byPath.set("sess", "root", { domain: "example.com", path: "/" });
+      byPath.set("sess", "api", { domain: "example.com", path: "/api" });
+      byPath.delete("sess", "example.com"); // path omitted
+      // Pre-patch: only the path="/" cookie was removed via the exact-key
+      // fast path; the "/api" cookie survived. Must still hold post-patch.
+      expect(byPath.size).toBe(1);
+      expect(byPath.getCookie("sess", "example.com", "/api")?.value).toBe("api");
+
+      // The collision case pass 1 exists for: both domain AND path supplied,
+      // exactly matching both records -- both must still be deleted in one
+      // call.
+      const collision = new Cookies();
+      collision.set("sess", "host-only-value", { domain: "example.com", path: "/", domainSpecified: false });
+      collision.set("sess", "domain-value", { domain: "example.com", path: "/", domainSpecified: true });
+      expect(collision.size).toBe(2);
+      collision.delete("sess", "example.com", "/");
+      expect(collision.size).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

RFC 6265 §5.3 step 6 treats a cookie set without a `Domain` attribute (host-only) and one set with an explicit `Domain` attribute as different identities, even when name/path/domain otherwise match. This package's cookie jar collapsed the two into a single record, silently discarding whichever was inserted second — e.g. a server response that sets both a host-only `sess` cookie and a `Domain=example.com` `sess` cookie in the same response (or across a redirect) loses one of them.

This adds finer-grained storage identity than the RFC's own minimum requires, rather than fixing non-compliance — it's an enhancement to this package's in-memory jar, not a spec-compliance fix.

## Changes

- `Cookie`/`CookieOptions` gain a `domainSpecified: boolean` field; `makeKey()` folds it into the storage key so the two kinds no longer collide.
- `set()`'s `domainSpecified` inference is explicit-value-aware (`??`, not `||`), so `clone()`/`update()` preserve an already-set `false` rather than re-inferring it from `domain` truthiness.
- `parseSetCookie()`'s request-hostname fallback now marks a backfilled domain as `domainSpecified: false`, closing the gap where a real host-only cookie arriving via the normal `Set-Cookie` parse path was still ambiguous.
- `toNetscapeFormat()`/`fromNetscapeFormat()` round-trip `domainSpecified` via the existing `includeSubdomains` column instead of re-deriving it from `domain` truthiness, so a host-only cookie survives a save/reload cycle correctly.
- Removing `get()`/`getCookie()`/`delete()`'s old single-key exact-match fast path (now ambiguous between the two kinds) surfaced a second, unrelated regression: an exact domain/path match no longer took priority over a broader fuzzy match regardless of insertion order.
  - `get()`/`getCookie()` now run an exact-scope pass (`matchesExactScope()`) before falling back to the pre-existing fuzzy scan.
  - `delete()` needed a *different* fix, not the same scan: applying `matchesExactScope()` to `delete()`'s "delete every match" pass would turn an omitted `domain` or `path` argument into an unbounded cascade across that axis. Instead, `delete()`'s exact-match pass does a direct two-key `Map` lookup (both `domainSpecified` values, at the caller's literal `domain`/`path` with `path` defaulting to `"/"` exactly as the old fast path did), which can't cascade because it isn't a scan.

## Explicitly out of scope

- `matchesDomain()`/`getForUrl()` still let a host-only cookie leak to subdomains — a separate, pre-existing send-scope gap (this PR only fixes storage identity), tracked as a follow-up.
- No changes to Public Suffix List handling, `SameSite` enforcement, or any other cookie-security concern.

## Test plan

- `npm test`: 97 passed, 0 failed (13 pre-existing skips, unrelated to this change).
- `tsc --noEmit` and `eslint` both clean.
- New tests cover: the storage collision itself (both directly and via the real `parseSetCookie()` → `set()` path), Netscape round-trip preservation, `get()`/`getCookie()` insertion-order resolution for a colliding pair, a regression guard for the exact-vs-fuzzy priority fix, a regression guard for `delete()`'s omitted-argument scoping, and a guard that the pre-existing dotted-domain dedup behavior (from #2) is unaffected.
- Checked against #2 (merged) and #24 (open): no overlap with either — #2's dot-normalization is exercised by an explicit regression test here, and #24 doesn't touch `cookies.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)