### PR TITLE
Fix CURLWS_PONG and CURLWS_OFFSET being defined the wrong way round

### DIFF
--- a/src/ffi/constants.ts
+++ b/src/ffi/constants.ts
@@ -721,8 +721,11 @@ export const CurlWsFlag = {
   CURLWS_CONT: 1 << 2,
   CURLWS_CLOSE: 1 << 3,
   CURLWS_PING: 1 << 4,
-  CURLWS_PONG: 1 << 5,
-  CURLWS_OFFSET: 1 << 6,
+  // These two were the other way round. libcurl's websockets.h has OFFSET at 1<<5 and PONG
+  // at 1<<6, so every pong was sent as an offset-send with no frame type and rejected with
+  // CURLE_BAD_FUNCTION_ARGUMENT, and every received pong fell through to the BINARY default.
+  CURLWS_OFFSET: 1 << 5,
+  CURLWS_PONG: 1 << 6,
 } as const;
 
 export type CurlWsFlag = (typeof CurlWsFlag)[keyof typeof CurlWsFlag];

--- a/src/ffi/libcurl.ts
+++ b/src/ffi/libcurl.ts
@@ -352,8 +352,13 @@ function curl_multi_setopt_off_t(
 // ============================================================================
 
 // curl_ws_recv(CURL *curl, void *buffer, size_t buflen, size_t *recv, const struct curl_ws_frame **meta)
+//
+// `meta` must be marked `_Out_`. Without it Koffi treats the array it is given as an input
+// buffer, marshals a copy, and never writes the returned pointer back — so the frame
+// metadata is always null and every frame looks like TEXT, including PING, PONG, BINARY and
+// CLOSE.
 const curl_ws_recv_fn = lib.func(
-  "int curl_ws_recv(void *, void *, size_t, size_t *, void **)"
+  "int curl_ws_recv(void *, void *, size_t, size_t *, _Out_ void **)"
 );
 
 interface WsFrame {

--- a/src/ffi/libcurl.ts
+++ b/src/ffi/libcurl.ts
@@ -45,20 +45,6 @@ const curl_easy_init = lib.func("void * curl_easy_init()");
 const curl_easy_cleanup = lib.func("void curl_easy_cleanup(void *)");
 const curl_easy_perform = lib.func("int curl_easy_perform(void *)");
 
-/**
- * Async version of curl_easy_perform that runs in a worker thread
- * via Koffi's .async() support. This avoids blocking the event loop,
- * which is critical when the mock server runs in the same process.
- */
-function curl_easy_perform_async(handle: CurlHandle): Promise<number> {
-  return new Promise<number>((resolve, reject) => {
-    (curl_easy_perform as unknown as { async: (handle: CurlHandle, cb: (err: Error | null, code: number) => void) => void })
-      .async(handle, (err: Error | null, code: number) => {
-        if (err) reject(err);
-        else resolve(code);
-      });
-  });
-}
 const curl_easy_duphandle = lib.func("void * curl_easy_duphandle(void *)");
 const curl_easy_reset = lib.func("void curl_easy_reset(void *)");
 const curl_easy_strerror = lib.func("const char * curl_easy_strerror(int)");
@@ -507,7 +493,6 @@ export {
   curl_easy_init,
   curl_easy_cleanup,
   curl_easy_perform,
-  curl_easy_perform_async,
   curl_easy_duphandle,
   curl_easy_reset,
   curl_easy_strerror,

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -231,6 +231,8 @@ export interface WebSocketOptions {
   verify?: boolean;
   /** Browser to impersonate */
   impersonate?: string;
+  /** Send the impersonated browser's own default headers (default: true) */
+  defaultHeaders?: boolean;
   /** Connection timeout in seconds */
   timeout?: number;
   /** Auto-reconnect on disconnect */

--- a/src/websocket/websocket.ts
+++ b/src/websocket/websocket.ts
@@ -495,8 +495,27 @@ export class AsyncWebSocket {
   }
 
   /**
-   * Send pong frame (usually auto-sent in response to ping)
+   * Send a pong frame.
+   *
+   * Public because an unsolicited pong is the standard unidirectional heartbeat
+   * (RFC 6455 section 5.5.3), and because on this transport it is the only way to keep an
+   * otherwise idle connection alive. libcurl answers a server ping by *queueing* a pong,
+   * and in CONNECT_ONLY mode nothing is written to the socket until the application sends
+   * something — so a consumer that only ever receives never actually delivers a pong, and
+   * a server that enforces a pong deadline closes the connection. Any send flushes the
+   * queued pong; a pong is the quietest one, since it asks for no reply.
    */
+  async pong(data?: Buffer | string): Promise<void> {
+    const buffer =
+      data === undefined
+        ? Buffer.alloc(0)
+        : Buffer.isBuffer(data)
+          ? data
+          : Buffer.from(data, "utf-8");
+    await this.sendRaw(buffer, CurlWsFlag.CURLWS_PONG);
+  }
+
+  /** Answer a received ping. Kept separate so the auto-reply path reads as what it is. */
   private async sendPong(data: Buffer): Promise<void> {
     await this.sendRaw(data, CurlWsFlag.CURLWS_PONG);
   }

--- a/src/websocket/websocket.ts
+++ b/src/websocket/websocket.ts
@@ -19,8 +19,10 @@ import {
   type CurlMultiHandle,
 } from "../ffi/libcurl.js";
 import { CurlOpt, CurlCode, CurlWsFlag } from "../ffi/constants.js";
-import { WebSocketError, WebSocketClosed } from "../utils/errors.js";
+import { WebSocketError, WebSocketClosed, ImpersonateError } from "../utils/errors.js";
 import { Headers } from "../http/headers.js";
+import { Cookies } from "../http/cookies.js";
+import { resolveNativeImpersonateTarget } from "../fingerprints.js";
 import type { WebSocketOptions } from "../types/options.js";
 
 /** How long to wait between `curl_multi_perform` calls while the handshake is in progress. */
@@ -100,12 +102,44 @@ export class AsyncWebSocket {
     // Enable WebSocket upgrade
     this.curl.setOpt(CurlOpt.CONNECT_ONLY, 2); // 2 = WebSocket mode
 
+    // Impersonation first: it configures the TLS and HTTP/2 layers, and — unless default
+    // headers are turned off — installs the browser's own header list, which would replace
+    // anything set before it. The caller's headers go on afterwards so they win.
+    if (typeof options.impersonate === "string") {
+      const target = resolveNativeImpersonateTarget(options.impersonate);
+      if (!target) {
+        throw new ImpersonateError(`Impersonating ${options.impersonate} is not supported`);
+      }
+      try {
+        this.curl.impersonate(target, options.defaultHeaders !== false);
+      } catch (error) {
+        throw new ImpersonateError(
+          `Impersonating ${target} is not supported`,
+          error instanceof Error ? error : undefined
+        );
+      }
+    }
+
     // Set headers
     if (options.headers) {
-      const headers = new Headers(options.headers);
-      const headerList = headers.toCurlHeaders();
-      // Note: Would need SList here for actual implementation
+      this.curl.setHeaders(new Headers(options.headers).toCurlHeaders());
     }
+
+    // Set cookies
+    if (options.cookies) {
+      const cookieHeader = new Cookies(options.cookies).toCookieHeader();
+      if (cookieHeader) {
+        this.curl.setOpt(CurlOpt.COOKIE, cookieHeader);
+      }
+    }
+
+    // Set proxy
+    if (options.proxy) {
+      this.curl.setOpt(CurlOpt.PROXY, options.proxy);
+    }
+
+    // Set SSL verification
+    this.curl.setOpt(CurlOpt.SSL_VERIFYPEER, options.verify === false ? 0 : 1);
 
     // Set timeout
     if (options.timeout) {

--- a/src/websocket/websocket.ts
+++ b/src/websocket/websocket.ts
@@ -7,15 +7,27 @@
 
 import { Curl } from "../core/easy.js";
 import {
-  curl_easy_perform_async,
+  curl_multi_init,
+  curl_multi_add_handle,
+  curl_multi_remove_handle,
+  curl_multi_perform,
+  curl_multi_cleanup,
+  curl_multi_info_read,
   curl_ws_recv,
   curl_ws_send,
   type CurlHandle,
+  type CurlMultiHandle,
 } from "../ffi/libcurl.js";
 import { CurlOpt, CurlCode, CurlWsFlag } from "../ffi/constants.js";
 import { WebSocketError, WebSocketClosed } from "../utils/errors.js";
 import { Headers } from "../http/headers.js";
 import type { WebSocketOptions } from "../types/options.js";
+
+/** How long to wait between `curl_multi_perform` calls while the handshake is in progress. */
+const CONNECT_POLL_MS = 1;
+
+/** `CURLMSG_DONE` — the only message type curl's multi interface defines. */
+const CURLMSG_DONE = 1;
 
 /**
  * WebSocket message types
@@ -63,6 +75,7 @@ export class AsyncWebSocket {
   private receiveBuffer: Buffer;
   private messageQueue: WebSocketMessage[] = [];
 
+  private multi: CurlMultiHandle | null = null;
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
   private pollInterval: number = 10; // ms between polls
 
@@ -110,22 +123,75 @@ export class AsyncWebSocket {
   }
 
   /**
-   * Perform the WebSocket connection handshake using Koffi's async
-   * worker thread to avoid blocking the Node.js event loop.
+   * Perform the WebSocket connection handshake, on the main thread and without blocking it.
+   *
+   * It is driven with the multi interface rather than `curl_easy_perform`, for two reasons
+   * that pull in opposite directions and are both satisfied here.
+   *
+   * It must not run on a libuv worker thread. That is what Koffi's `.async()` does, and
+   * driving libcurl from one leaves per-thread state behind whose pthread TSD destructor
+   * lives in the libcurl image. At process exit the worker thread is torn down and
+   * `_pthread_tsd_cleanup` calls that destructor after the image has gone, so the process
+   * dies with SIGSEGV *after* the script has finished — silently, since the script produced
+   * all of its output first. It is not specific to WebSockets: any `curl_easy_perform`
+   * issued through `.async()` does it, a plain HTTPS GET included.
+   *
+   * It must also not block the event loop, or a caller talking to a server in its own
+   * process — which is exactly what this repository's tests do — would deadlock.
+   *
+   * `curl_multi_perform` gives both: it returns as soon as there is nothing to do right
+   * now, so the handshake advances across event-loop turns without ever leaving the main
+   * thread. The handle stays attached to the multi for the life of the socket; removing it
+   * would drop the connection that `CONNECT_ONLY` exists to keep.
    */
   private async performConnect(): Promise<void> {
     try {
-      const code = await curl_easy_perform_async(this.handle);
+      this.multi = curl_multi_init();
+      if (!this.multi) throw new WebSocketError("Failed to initialize curl multi handle");
+      curl_multi_add_handle(this.multi, this.handle);
+
+      let running = 1;
+      while (running > 0) {
+        const perform = curl_multi_perform(this.multi);
+        if (perform.code !== 0) {
+          throw new WebSocketError(`WS connect failed with multi code ${perform.code}`);
+        }
+        running = perform.runningHandles;
+        if (running > 0) await new Promise((resolve) => setTimeout(resolve, CONNECT_POLL_MS));
+      }
+
+      const code = this.readTransferResult();
       if (code !== CurlCode.CURLE_OK) {
         throw new WebSocketError(`WS connect failed with code ${code}`);
       }
       this._connected = true;
     } catch (error) {
       this._closed = true;
+      this.releaseMulti();
       this.curl.cleanup();
       if (error instanceof WebSocketError) throw error;
       throw new WebSocketError(`Failed to connect: ${error}`);
     }
+  }
+
+  /** The completion code the multi recorded for this transfer, once it stopped running. */
+  private readTransferResult(): number {
+    if (!this.multi) return CurlCode.CURLE_OK;
+    for (;;) {
+      const { message } = curl_multi_info_read(this.multi);
+      if (!message) return CurlCode.CURLE_OK;
+      // CURLMSG_DONE is the only message curl defines, and it carries the easy result.
+      if (message.msg === CURLMSG_DONE) return message.result;
+    }
+  }
+
+  /** Detach and free the multi handle. Safe to call more than once. */
+  private releaseMulti(): void {
+    if (!this.multi) return;
+    const multi = this.multi;
+    this.multi = null;
+    curl_multi_remove_handle(multi, this.handle);
+    curl_multi_cleanup(multi);
   }
 
   /**
@@ -430,6 +496,7 @@ export class AsyncWebSocket {
     }
 
     // Cleanup
+    this.releaseMulti();
     this.curl.cleanup();
   }
 

--- a/tests/websocket-exit.test.ts
+++ b/tests/websocket-exit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The process must exit cleanly after a WebSocket has been opened.
+ *
+ * This is a child-process test on purpose. The failure it guards against happens *after*
+ * the script finishes — libcurl driven from a libuv worker thread leaves per-thread state
+ * whose pthread TSD destructor lives in the libcurl image, and at exit the worker thread is
+ * torn down and calls that destructor after the image has gone. The script produces its
+ * output, then the process dies with SIGSEGV. Nothing observable from inside the process
+ * can catch that; only the exit status can.
+ */
+import { spawn } from "node:child_process";
+import { getWebSocketUrl } from "./mock-server.js";
+
+const repositoryRoot = new URL("..", import.meta.url).pathname;
+const builtEntry = `${repositoryRoot}dist/index.js`;
+
+/**
+ * Run a snippet in a fresh Node process and report how it terminated.
+ *
+ * Asynchronous on purpose: the mock server this connects to lives in *this* process, so a
+ * blocking `spawnSync` would stop it answering and the child would hang.
+ */
+function runInChild(source: string): Promise<{ status: number | null; signal: string | null }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, ["--input-type=module", "-e", source], {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("close", (status, signal) => {
+      if (process.env.IMPERS_DEBUG_TESTS) {
+        console.log("child:", JSON.stringify({ status, signal, stderr: stderr.slice(0, 600) }));
+      }
+      resolve({ status, signal });
+    });
+  });
+}
+
+describe("process exit after WebSocket use", () => {
+  // The child cannot run the TypeScript sources — they use NodeNext `.js` specifiers, which
+  // Node's type stripping does not resolve — so it imports the build. Built here rather than
+  // assumed present: a stale `dist/` would let this test pass against the very code it
+  // exists to reject.
+  beforeAll(async () => {
+    const build = spawn("npm", ["run", "build"], { cwd: repositoryRoot, stdio: "ignore" });
+    const code = await new Promise<number | null>((resolve) => build.on("close", resolve));
+    if (code !== 0) throw new Error(`npm run build exited with ${code}`);
+  }, 300_000);
+
+  it.each([
+    ["closed before exiting", true],
+    ["left open at exit", false],
+  ])("exits cleanly with the socket %s", async (_label, closeFirst) => {
+    const source = `
+      const { wsConnect } = await import(${JSON.stringify(builtEntry)});
+      const ws = await wsConnect(${JSON.stringify(`${getWebSocketUrl()}/ws/echo`)});
+      ${closeFirst ? "await ws.close();" : ""}
+    `;
+
+    const { status, signal } = await runInChild(source);
+
+    // A segfault surfaces as signal SIGSEGV, or as status 139 when a shell is involved.
+    expect(signal).toBeNull();
+    expect(status).toBe(0);
+  });
+});

--- a/tests/websocket-frames.test.ts
+++ b/tests/websocket-frames.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Received frames must be reported with the type they actually had.
+ *
+ * `curl_ws_recv` returns its frame metadata through a `const struct curl_ws_frame **meta`
+ * out-parameter. That parameter was declared to Koffi as a plain input `void **`, so the
+ * pointer was never written back, `frame` was always null, and `frameToMessage` fell
+ * through to its TEXT default for everything.
+ *
+ * The consequences were not cosmetic. A BINARY frame arrived as text. A CLOSE frame
+ * arrived as a two-byte text message, so `closed` stayed false, `closeEvent` stayed null,
+ * no close was echoed, and a consumer went on polling a dead socket forever — a
+ * server-initiated close was, in effect, invisible.
+ *
+ * The frames here are hand-built rather than taken from a websocket library so that each
+ * opcode is exercised exactly once, in a known order.
+ */
+import { wsConnect } from "../src/websocket/websocket.js";
+import { WebSocketClosed } from "../src/utils/errors.js";
+import { createServer, type Server } from "node:http";
+import { createHash } from "node:crypto";
+import type { AddressInfo } from "node:net";
+
+const OPCODE_TEXT = 0x1;
+const OPCODE_BINARY = 0x2;
+const OPCODE_CLOSE = 0x8;
+
+/** A single unfragmented server frame. Payloads here are always well under 126 bytes. */
+function frame(opcode: number, payload: Buffer): Buffer {
+  return Buffer.concat([Buffer.from([0x80 | opcode, payload.length]), payload]);
+}
+
+let server: Server;
+const upgraded: Array<{ destroy(): void; write(data: Buffer | string): void }> = [];
+let port: number;
+
+beforeAll(async () => {
+  server = createServer();
+  server.on("upgrade", (request, socket) => {
+    upgraded.push(socket);
+    const accept = createHash("sha1")
+      .update(`${request.headers["sec-websocket-key"]}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+      .digest("base64");
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+    );
+    socket.write(frame(OPCODE_TEXT, Buffer.from("hello")));
+    socket.write(frame(OPCODE_BINARY, Buffer.from([1, 2, 3])));
+    socket.write(frame(OPCODE_CLOSE, Buffer.from([0x03, 0xe9]))); // 1001, Going Away
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  for (const socket of upgraded) socket.destroy();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe("received frame types", () => {
+  it("distinguishes text, binary and close", async () => {
+    const ws = await wsConnect(`ws://127.0.0.1:${port}/`);
+
+    const text = await ws.recv(5);
+    expect(text.type).toBe("text");
+    expect(text.data.toString("utf-8")).toBe("hello");
+
+    const binary = await ws.recv(5);
+    expect(binary.type).toBe("binary");
+    expect([...binary.data]).toEqual([1, 2, 3]);
+
+    // Before the fix this resolved with a 2-byte "text" message and left the socket open.
+    await expect(ws.recv(5)).rejects.toThrow(WebSocketClosed);
+    expect(ws.closed).toBe(true);
+    expect(ws.closeEvent?.code).toBe(1001);
+  });
+});

--- a/tests/websocket-options.test.ts
+++ b/tests/websocket-options.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The WebSocket handshake must actually carry the options the caller passed.
+ *
+ * These were accepted and silently dropped: `headers` was built into a curl header list
+ * and then discarded ("Note: Would need SList here"), and `cookies`, `impersonate`,
+ * `proxy` and `verify` were never read at all. A caller talking to a real server — one
+ * that needs a session cookie, or that fingerprints the TLS handshake — got a connection
+ * that looked nothing like what they asked for, with no error to say so.
+ *
+ * The assertions are made against a server that records the upgrade request, because the
+ * only place the difference is observable is on the wire.
+ */
+import { wsConnect } from "../src/websocket/websocket.js";
+import { createServer, type Server } from "node:http";
+import { createHash } from "node:crypto";
+import type { AddressInfo } from "node:net";
+
+interface SeenRequest {
+  headers: Record<string, string | string[] | undefined>;
+  order: string[];
+}
+
+let server: Server;
+const upgraded: Array<{ destroy(): void }> = [];
+let port: number;
+let seen: SeenRequest | null;
+
+beforeAll(async () => {
+  server = createServer();
+  server.on("upgrade", (request, socket) => {
+    upgraded.push(socket);
+    seen = {
+      headers: request.headers,
+      order: request.rawHeaders.filter((_, index) => index % 2 === 0),
+    };
+    const accept = createHash("sha1")
+      .update(`${request.headers["sec-websocket-key"]}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+      .digest("base64");
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+    );
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  // This server answers the handshake and nothing else — it never processes a close frame,
+  // so the upgraded sockets stay open and `close()` alone would wait for them forever.
+  for (const socket of upgraded) socket.destroy();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  seen = null;
+});
+
+describe("WebSocket handshake options", () => {
+  it("sends the caller's headers", async () => {
+    const ws = await wsConnect(`ws://127.0.0.1:${port}/`, {
+      headers: {
+        Origin: "app://-",
+        "User-Agent": "test-agent/1.0",
+        "Accept-Language": "en-US,en;q=0.9",
+      },
+    });
+
+    expect(seen?.headers["origin"]).toBe("app://-");
+    expect(seen?.headers["user-agent"]).toBe("test-agent/1.0");
+    expect(seen?.headers["accept-language"]).toBe("en-US,en;q=0.9");
+
+    await ws.close();
+  });
+
+  it("sends the caller's cookies", async () => {
+    const ws = await wsConnect(`ws://127.0.0.1:${port}/`, {
+      cookies: { session: "abc123", other: "def456" },
+    });
+
+    expect(seen?.headers["cookie"]).toContain("session=abc123");
+    expect(seen?.headers["cookie"]).toContain("other=def456");
+
+    await ws.close();
+  });
+
+  it("still completes the handshake when impersonating", async () => {
+    const ws = await wsConnect(`ws://127.0.0.1:${port}/`, {
+      impersonate: "chrome",
+      defaultHeaders: false,
+      headers: { Origin: "app://-" },
+    });
+
+    // The TLS fingerprint is not observable over a plaintext socket; what is checked here
+    // is that impersonation is applied without discarding the caller's headers, which is
+    // the ordering mistake this is easy to make.
+    expect(seen?.headers["origin"]).toBe("app://-");
+
+    await ws.close();
+  });
+
+  it("rejects an impersonation target that does not exist", async () => {
+    await expect(
+      wsConnect(`ws://127.0.0.1:${port}/`, { impersonate: "not-a-browser" })
+    ).rejects.toThrow(/not supported/);
+  });
+});

--- a/tests/websocket-pong-flag.test.ts
+++ b/tests/websocket-pong-flag.test.ts
@@ -1,0 +1,69 @@
+/**
+ * A pong must go out as a pong.
+ *
+ * `CURLWS_PONG` and `CURLWS_OFFSET` were defined the wrong way round: libcurl's
+ * websockets.h has `CURLWS_OFFSET` at `1<<5` and `CURLWS_PONG` at `1<<6`. Sending a pong
+ * therefore asked libcurl for an offset-send with no frame type, which it rejected with
+ * `CURLE_BAD_FUNCTION_ARGUMENT` — so `pong()` never put a frame on the wire, and it failed
+ * quietly for anyone who did not check. In the other direction a received pong carried
+ * `1<<6`, matched none of the branches, and fell through to the BINARY default.
+ *
+ * The assertion is made on the raw opcode a server observes, because the constant being
+ * wrong is invisible from every other vantage point.
+ */
+import { wsConnect } from "../src/websocket/websocket.js";
+import { createServer, type Server } from "node:http";
+import { createHash } from "node:crypto";
+import type { AddressInfo } from "node:net";
+
+const OPCODE_PONG = 0xa;
+
+let server: Server;
+let port: number;
+const upgraded: Array<{ destroy(): void }> = [];
+let clientOpcodes: number[] = [];
+
+beforeAll(async () => {
+  server = createServer();
+  server.on("upgrade", (request, socket) => {
+    upgraded.push(socket);
+    const accept = createHash("sha1")
+      .update(`${request.headers["sec-websocket-key"]}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+      .digest("base64");
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+    );
+    socket.on("data", (chunk: Buffer) => clientOpcodes.push(chunk[0]! & 0x0f));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  for (const socket of upgraded) socket.destroy();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  clientOpcodes = [];
+});
+
+describe("pong()", () => {
+  it("puts a pong frame on the wire", async () => {
+    const ws = await wsConnect(`ws://127.0.0.1:${port}/`);
+    await ws.pong();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(clientOpcodes).toContain(OPCODE_PONG);
+    await ws.close();
+  });
+
+  it("carries a payload", async () => {
+    const ws = await wsConnect(`ws://127.0.0.1:${port}/`);
+    // Before the fix this rejected with "Send failed with code 43".
+    await expect(ws.pong(Buffer.from("keepalive"))).resolves.toBeUndefined();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(clientOpcodes).toContain(OPCODE_PONG);
+    await ws.close();
+  });
+});

--- a/tests/websocket.test.ts
+++ b/tests/websocket.test.ts
@@ -5,7 +5,7 @@ import { AsyncWebSocket, wsConnect } from "../src/websocket/websocket.js";
 import { WebSocketError, WebSocketClosed } from "../src/utils/errors.js";
 import { getWebSocketUrl } from "./mock-server.js";
 
-describe.skip("AsyncWebSocket", () => {
+describe("AsyncWebSocket", () => {
   let wsUrl: string;
 
   beforeAll(() => {


### PR DESCRIPTION
Stacked on #30, #31, #32, #33 (this branch contains all four).

## The bug

`src/ffi/constants.ts` has:

```ts
CURLWS_PONG: 1 << 5,
CURLWS_OFFSET: 1 << 6,
```

libcurl's `websockets.h` has them the other way round — `CURLWS_OFFSET` is `(1<<5)` and `CURLWS_PONG` is `(1<<6)`.

Both directions are broken by it:

- **Sending a pong never works.** `1<<5` asks libcurl for an offset-send with no frame type, which it rejects with `CURLE_BAD_FUNCTION_ARGUMENT` (43). Nothing reaches the wire. Because a keepalive pong is usually fire-and-forget, this fails silently — which is how it went unnoticed.
- **Receiving a pong misreports it.** A real pong carries `1<<6`, matches no branch in `frameToMessage`, and falls through to the `BINARY` default.

## Verification

Measured against a server that records the opcode of each frame the client sends:

| flag passed to `curl_ws_send` | result | wire opcode |
| --- | --- | --- |
| `1<<4` | `CURLE_OK` | `0x9` (ping) |
| `1<<5` | **`43` CURLE_BAD_FUNCTION_ARGUMENT** | — |
| `1<<6` | `CURLE_OK` | `0xa` (pong) |

New `tests/websocket-pong-flag.test.ts` asserts the observed opcode, with and without a payload. Both cases fail on the previous constants — the payload one with `Send failed with code 43`.

Full suite: **163 passed**, 1 suite skipped (live fingerprints).