### PR TITLE
Fix support for WebSocket Headers

### DIFF
--- a/src/websocket/websocket.ts
+++ b/src/websocket/websocket.ts
@@ -91,7 +91,8 @@ export class AsyncWebSocket {
     if (options.headers) {
       const headers = new Headers(options.headers);
       const headerList = headers.toCurlHeaders();
-      // Note: Would need SList here for actual implementation
+      
+      this.curl.setStringList(CurlOpt.HTTPHEADER, headerList);
     }
 
     // Set timeout


### PR DESCRIPTION
Currently the WebSocket lacks support for headers because of lacking the code that sets the actual CURL option. This is a simple edit to include that.